### PR TITLE
Update Dwellir RPC URLs for Kusama and Polkadot

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ pub(super) use subxt::utils::H256;
 // Kusama Chains -----------------------------------------------------------------------------------
 
 #[subxt::subxt(
-	runtime_metadata_insecure_url = "wss://kusama-rpc.dwellir.com:443",
+	runtime_metadata_insecure_url = "wss://kusama-rpc.n.dwellir.com:443",
 	derive_for_all_types = "PartialEq, Clone"
 )]
 pub mod kusama_relay {}
@@ -22,7 +22,7 @@ pub(super) use kusama_asset_hub::runtime_types::asset_hub_kusama_runtime::Runtim
 pub mod kusama_bridge_hub {}
 pub(super) use kusama_bridge_hub::runtime_types::bridge_hub_kusama_runtime::RuntimeCall as KusamaBridgeHubRuntimeCall;
 
-#[subxt::subxt(runtime_metadata_insecure_url = "wss://encointer-kusama-rpc.dwellir.com:443")]
+#[subxt::subxt(runtime_metadata_insecure_url = "wss://encointer-kusama-rpc.n.dwellir.com:443")]
 pub mod kusama_encointer {}
 pub(super) use kusama_encointer::runtime_types::encointer_kusama_runtime::RuntimeCall as KusamaEncointerRuntimeCall;
 
@@ -37,7 +37,7 @@ pub(super) use kusama_coretime::runtime_types::coretime_kusama_runtime::RuntimeC
 // Polkadot Chains ---------------------------------------------------------------------------------
 
 #[subxt::subxt(
-	runtime_metadata_insecure_url = "wss://polkadot-rpc.dwellir.com:443",
+	runtime_metadata_insecure_url = "wss://polkadot-rpc.n.dwellir.com:443",
 	derive_for_all_types = "PartialEq, Clone"
 )]
 pub mod polkadot_relay {}
@@ -461,13 +461,13 @@ impl CallInfo {
 		use subxt::{OnlineClient, PolkadotConfig};
 
 		let url = match network {
-			Network::Kusama => "wss://kusama-rpc.dwellir.com:443",
+			Network::Kusama => "wss://kusama-rpc.n.dwellir.com:443",
 			Network::KusamaAssetHub => "wss://kusama-asset-hub-rpc.polkadot.io:443",
 			Network::KusamaBridgeHub => "wss://kusama-bridge-hub-rpc.polkadot.io:443",
 			Network::KusamaPeople => "wss://kusama-people-rpc.polkadot.io:443",
 			Network::KusamaCoretime => "wss://kusama-coretime-rpc.polkadot.io:443",
-			Network::KusamaEncointer => "wss://encointer-kusama-rpc.dwellir.com:443",
-			Network::Polkadot => "wss://polkadot-rpc.dwellir.com:443",
+			Network::KusamaEncointer => "wss://encointer-kusama-rpc.n.dwellir.com:443",
+			Network::Polkadot => "wss://polkadot-rpc.n.dwellir.com:443",
 			Network::PolkadotAssetHub => "wss://polkadot-asset-hub-rpc.polkadot.io:443",
 			Network::PolkadotCollectives => "wss://polkadot-collectives-rpc.polkadot.io:443",
 			Network::PolkadotBridgeHub => "wss://polkadot-bridge-hub-rpc.polkadot.io:443",


### PR DESCRIPTION
Updated the WebSocket endpoint URLs for Kusama, Polkadot, and Encointer chains to use the new Dwellir url (‎`*.n.dwellir.com`). 