### PR TITLE
Add `register-system-para` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This program's primary purpose is to construct all the needed calls to submit a proposal as an OpenGov referendum on Kusama or Polkadot. It assumes that you construct the proposal (i.e., the privileged call you want to execute) elsewhere (e.g. Polkadot JS Apps UI Extrinsics tab). It will return all the calls that you will need to sign and submit (also using, e.g., the Apps UI Extrinsics tab). Note that you may need to submit calls on multiple chains.
 
-It also provides a utility to construct a runtime upgrade call that will batch the upgrades of the Kusama or Polkadot Relay Chain with the upgrades of all their respective system parachains.
+It also provides utilities to construct a runtime upgrade call that will batch the upgrades of the Kusama or Polkadot Relay Chain with all their respective system parachains, and to register new system parachains via the whitelist+preimage pattern.
 
 ## CLI
 
@@ -18,9 +18,10 @@ Utilities for submitting OpenGov referenda and constructing tedious calls
 Usage: opengov-cli <COMMAND>
 
 Commands:
-  build-upgrade      Generate a single call that will upgrade a Relay Chain and all of its system parachains
-  submit-referendum  Generate all the calls needed to submit a proposal as a referendum in OpenGov
-  help               Print this message or the help of the given subcommand(s)
+  build-upgrade         Generate a single call that will upgrade a Relay Chain and all of its system parachains
+  register-system-para  Generate the calls needed to register a system parachain via Asset Hub governance
+  submit-referendum     Generate all the calls needed to submit a proposal as a referendum in OpenGov
+  help                  Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -80,6 +81,37 @@ Options:
   -h, --help                           Print help
 ```
 
+### Register System Para
+
+The `register-system-para` subcommand takes a WASM runtime, genesis head, and parachain ID and generates all the calls needed to register a system parachain on the relay chain via Asset Hub governance.
+
+Because `force_register` includes the full WASM runtime (~1 MB+), it exceeds the 128 KB UMP message limit. The command uses the whitelist+preimage pattern: the large call is stored as a preimage on the relay chain, while Asset Hub sends a tiny XCM that whitelists and dispatches it. Asset Hub has Root on the relay chain via `LocationAsSuperuser`.
+
+```
+$ ./target/debug/opengov-cli register-system-para --help
+Generate the calls needed to register a system parachain via Asset Hub governance
+
+Usage: opengov-cli register-system-para [OPTIONS] --wasm <WASM> --genesis-head <GENESIS_HEAD> --para-id <PARA_ID> --network <NETWORK> --manager <MANAGER>
+
+Options:
+      --wasm <WASM>                Path to the WASM validation code file
+      --genesis-head <GENESIS_HEAD>  Path to the genesis head hex file (from: polkadot-omni-node export-genesis-head)
+      --para-id <PARA_ID>          Parachain ID to register
+  -n, --network <NETWORK>          Network: `polkadot` or `kusama`
+      --manager <MANAGER>          Manager account SS58 address
+      --deposit <DEPOSIT>          Deposit in plancks [default: 0]
+      --ref-time <REF_TIME>        Weight ref_time witness for dispatch_whitelisted_call [default: 60000000000]
+      --proof-size <PROOF_SIZE>    Weight proof_size witness for dispatch_whitelisted_call [default: 10000]
+      --filename <FILENAME>        Output file name for the Asset Hub proposal
+  -h, --help                       Print help
+```
+
+The genesis head can be exported with:
+
+```
+polkadot-omni-node export-genesis-head --chain <chainspec.json> > genesis-head.hex
+```
+
 ## Examples
 
 ### Build Upgrade
@@ -113,6 +145,74 @@ opengov-cli submit-referendum \
     --proposal "./upgrade-polkadot-1.0.0/polkadot-1.0.0.call" \
     --network "polkadot" --track <"root" or "whitelistedcaller">
 ```
+
+### Register a System Parachain on Polkadot
+
+First, generate the registration calls:
+
+```
+$ ./target/release/opengov-cli register-system-para \
+	--wasm ./bulletin_runtime.wasm \
+	--genesis-head ./genesis-head.hex \
+	--para-id 1010 \
+	--network polkadot \
+	--manager 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+
+WASM size: 1108030 bytes
+Genesis head size: 98 bytes
+ParaId: 1010
+Manager: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+Deposit: 0
+
+force_register call:
+  Encoded size: 1108188 bytes
+  Hash: 0x9b31b2d4b51f124751ebb7d8fc37bbc9633597cc897cb646235d00441e4626ba
+  Written to: force_register_call.hex
+
+Whitelist calls (relay chain, for XCM):
+  whitelist_call: 34 bytes
+  dispatch_whitelisted_call: 46 bytes
+
+============================================================
+  REGISTER SYSTEM PARACHAIN 1010
+============================================================
+
+  STEP 1 — Submit on Relay Chain (permissionless):
+    Use force_register_call.hex (1108188 bytes) as the bytes for
+    Preimage.note_preimage in any wallet (e.g. Polkadot JS Apps).
+
+  STEP 2 — Submit as referendum:
+    register-system-para-1010.call (111 bytes)
+
+    opengov-cli submit-referendum \
+      --proposal "register-system-para-1010.call" \
+      --network "polkadot" --track whitelistedcaller
+============================================================
+```
+
+Then, pipe the proposal into `submit-referendum` to generate the Fellowship and public referendum calls:
+
+```
+$ ./target/release/opengov-cli submit-referendum \
+	--proposal "register-system-para-1010.call" \
+	--network "polkadot" --track "whitelistedcaller" \
+	--output calldata --no-batch
+
+Open a Fellowship referendum to whitelist the call:
+0x3d003e0201cc...
+
+Submit the preimage for the public referendum:
+0x0500c5014003...
+
+Open a public referendum to dispatch the call:
+0x3e003f0d02ec...
+```
+
+This produces three calls to submit (in any order):
+
+1. **Relay Chain** (permissionless): Use `force_register_call.hex` as the bytes for `Preimage.note_preimage` in any wallet. This stores the ~1.1 MB `force_register` call on-chain.
+2. **Collectives Chain** (any Fellow): Submit the Fellowship referendum call. When Fellows approve, it whitelists the Asset Hub proposal.
+3. **Asset Hub** (anyone): Submit the preimage call and the public referendum call. When the public vote passes, it dispatches a `batch_all` of two XCM messages to the relay chain that whitelist and execute the `force_register` call.
 
 ### Submit a Referendum on Kusama
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ Options:
       --wasm <WASM>                Path to the WASM validation code file
       --genesis-head <GENESIS_HEAD>  Path to the genesis head hex file (from: polkadot-omni-node export-genesis-head)
       --para-id <PARA_ID>          Parachain ID to register
-  -n, --network <NETWORK>          Network: `polkadot` or `kusama`
+  -n, --network <NETWORK>          Network. Currently only `polkadot` is supported
       --manager <MANAGER>          Manager account SS58 address
       --deposit <DEPOSIT>          Deposit in plancks [default: 0]
-      --ref-time <REF_TIME>        Weight ref_time witness for dispatch_whitelisted_call [default: 60000000000]
-      --proof-size <PROOF_SIZE>    Weight proof_size witness for dispatch_whitelisted_call [default: 10000]
+      --ref-time <REF_TIME>        Weight ref_time witness for dispatch_whitelisted_call [default: 10000000000]
+      --proof-size <PROOF_SIZE>    Weight proof_size witness for dispatch_whitelisted_call [default: 5000]
+      --assign-core <CORE>         Reserve a dedicated core via broker.force_reserve on the Coretime chain
       --filename <FILENAME>        Output file name for the Asset Hub proposal
   -h, --help                       Print help
 ```
@@ -148,7 +149,7 @@ opengov-cli submit-referendum \
 
 ### Register a System Parachain on Polkadot
 
-First, generate the registration calls:
+First, generate the registration calls. Use `--assign-core` to also reserve a dedicated core on the Coretime chain via `broker.force_reserve`:
 
 ```
 $ ./target/release/opengov-cli register-system-para \
@@ -156,22 +157,20 @@ $ ./target/release/opengov-cli register-system-para \
 	--genesis-head ./genesis-head.hex \
 	--para-id 1010 \
 	--network polkadot \
-	--manager 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+	--manager 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
+	--assign-core 99
 
 WASM size: 1108030 bytes
 Genesis head size: 98 bytes
 ParaId: 1010
 Manager: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 Deposit: 0
+Assign core: 67 (via broker.force_reserve on Coretime chain)
 
 force_register call:
   Encoded size: 1108188 bytes
-  Hash: 0x9b31b2d4b51f124751ebb7d8fc37bbc9633597cc897cb646235d00441e4626ba
+  Hash: 0x9b31...4626ba
   Written to: force_register_call.hex
-
-Whitelist calls (relay chain, for XCM):
-  whitelist_call: 34 bytes
-  dispatch_whitelisted_call: 46 bytes
 
 ============================================================
   REGISTER SYSTEM PARACHAIN 1010
@@ -182,8 +181,6 @@ Whitelist calls (relay chain, for XCM):
     Preimage.note_preimage in any wallet (e.g. Polkadot JS Apps).
 
   STEP 2 — Submit as referendum:
-    register-system-para-1010.call (111 bytes)
-
     opengov-cli submit-referendum \
       --proposal "register-system-para-1010.call" \
       --network "polkadot" --track whitelistedcaller
@@ -212,7 +209,10 @@ This produces three calls to submit (submissions can happen in any order, but th
 
 1. **Relay Chain** (permissionless): Use `force_register_call.hex` as the bytes for `Preimage.note_preimage` in any wallet. This stores the ~1.1 MB `force_register` call on-chain.
 2. **Collectives Chain** (any Fellow): Submit the Fellowship referendum call. When Fellows approve, it whitelists the Asset Hub proposal.
-3. **Asset Hub** (anyone): Submit the preimage call and the public referendum call. When the public vote passes, it dispatches a `batch_all` of two XCM messages to the relay chain that whitelist and execute the `force_register` call.
+3. **Asset Hub** (anyone): Submit the preimage call and the public referendum call. When the public vote passes, it dispatches a `batch_all` containing:
+   - XCM → Relay: `whitelist.whitelist_call(hash)`
+   - XCM → Relay: `whitelist.dispatch_whitelisted_call(hash)` → executes `force_register`
+   - XCM → Coretime chain: `broker.force_reserve(Task(1010), core=99)` (if `--assign-core` was used)
 
 ### Submit a Referendum on Kusama
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ First, generate the registration calls:
 
 ```
 $ ./target/release/opengov-cli register-system-para \
-	--wasm ./bulletin_runtime.wasm \
+	--wasm ./my_parachain_runtime.wasm \
 	--genesis-head ./genesis-head.hex \
 	--para-id 1010 \
 	--network polkadot \
@@ -208,7 +208,7 @@ Open a public referendum to dispatch the call:
 0x3e003f0d02ec...
 ```
 
-This produces three calls to submit (in any order):
+This produces three calls to submit (submissions can happen in any order, but the preimage on the relay chain must be stored before the Asset Hub referendum enacts):
 
 1. **Relay Chain** (permissionless): Use `force_register_call.hex` as the bytes for `Preimage.note_preimage` in any wallet. This stores the ~1.1 MB `force_register` call on-chain.
 2. **Collectives Chain** (any Fellow): Submit the Fellowship referendum call. When Fellows approve, it whitelists the Asset Hub proposal.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Genesis head size: 98 bytes
 ParaId: 1010
 Manager: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 Deposit: 0
-Assign core: 67 (via broker.force_reserve on Coretime chain)
+Assign core: 99 (via broker.force_reserve on Coretime chain)
 
 force_register call:
   Encoded size: 1108188 bytes
@@ -205,7 +205,7 @@ Open a public referendum to dispatch the call:
 0x3e003f0d02ec...
 ```
 
-This produces three calls to submit (submissions can happen in any order, but the preimage on the relay chain must be stored before the Asset Hub referendum enacts):
+This produces three calls to submit (submissions can happen in any order). If `--delay-whitelist-dispatch-relay` is used, the relay chain preimage should be submitted **after** enactment (during the delay window) for free; otherwise it must be stored before the referendum enacts:
 
 1. **Relay Chain** (permissionless): Use `force_register_call.hex` as the bytes for `Preimage.note_preimage` in any wallet. This stores the ~1.1 MB `force_register` call on-chain.
 2. **Collectives Chain** (any Fellow): Submit the Fellowship referendum call. When Fellows approve, it whitelists the Asset Hub proposal.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Commands:
   build-upgrade         Generate a single call that will upgrade a Relay Chain and all of its system parachains
   register-system-para  Generate the calls needed to register a system parachain via Asset Hub governance
   submit-referendum     Generate all the calls needed to submit a proposal as a referendum in OpenGov
+  xcm-force-register    Generate the whitelist+preimage pattern for a relay-chain force_register call
+  xcm-force-reserve     Generate an AH XCM send wrapping broker.force_reserve for the Coretime chain
+  batch-ah              Combine Asset Hub calls into a single Utility.batch_all proposal
   help                  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -112,6 +115,52 @@ The genesis head can be exported with:
 ```
 polkadot-omni-node export-genesis-head --chain <chainspec.json> > genesis-head.hex
 ```
+
+### Primitives
+
+For more complex proposals (e.g. registering a parachain **and** reserving cores for other parachains in the same referendum), the registration flow is decomposed into three composable subcommands:
+
+- **`xcm-force-register`** — produces the whitelist+preimage pattern for a relay-chain `Registrar.force_register` call. Outputs `preimage.hex`, `xcm_whitelist.hex`, and `xcm_dispatch.hex`.
+- **`xcm-force-reserve`** — produces an AH XCM send wrapping `Broker.force_reserve(para_id, core)` destined for the Coretime chain.
+- **`batch-ah`** — combines multiple Asset Hub call files into a single `Utility.batch_all` proposal.
+
+`register-system-para` itself is a convenience wrapper over these primitives.
+
+#### Multi-parachain example
+
+Register Bulletin (para 1010) and additionally reserve cores for two other parachains in one referendum:
+
+```
+# 1. Generate registration artifacts for para 1010
+$ ./target/debug/opengov-cli xcm-force-register \
+    --wasm ./bulletin.wasm \
+    --genesis-head ./genesis-head.hex \
+    --para-id 1010 \
+    --manager 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY \
+    --delay-whitelist-dispatch-relay 7200 \
+    --output reg_1010/
+# → reg_1010/preimage.hex, reg_1010/xcm_whitelist.hex, reg_1010/xcm_dispatch.hex
+
+# 2. Reserve cores for para 1010 and two additional paras
+$ ./target/debug/opengov-cli xcm-force-reserve --para-id 1010 --core 97  --output reserve_1010.hex
+$ ./target/debug/opengov-cli xcm-force-reserve --para-id 2020 --core 98 --output reserve_2020.hex
+$ ./target/debug/opengov-cli xcm-force-reserve --para-id 3030 --core 99 --output reserve_3030.hex
+
+# 3. Batch everything into a single AH proposal
+$ ./target/debug/opengov-cli batch-ah --output multi-para.call \
+    reg_1010/xcm_whitelist.hex \
+    reg_1010/xcm_dispatch.hex \
+    reserve_1010.hex \
+    reserve_2020.hex \
+    reserve_3030.hex
+
+# 4. Submit as a referendum (whitelisted-caller track)
+$ ./target/debug/opengov-cli submit-referendum \
+    --proposal multi-para.call \
+    --network polkadot --track whitelistedcaller
+```
+
+After enactment, submit `reg_1010/preimage.hex` via `Preimage.note_preimage` on the relay chain (free during the delay window, since `whitelist_call` marks the hash as requested).
 
 ## Examples
 

--- a/src/batch_ah.rs
+++ b/src/batch_ah.rs
@@ -1,0 +1,58 @@
+//! `batch-ah` subcommand.
+//!
+//! Reads one or more hex-encoded Asset Hub calls from input files and combines them
+//! into a single `Utility.batch_all` AH proposal.
+
+use crate::primitives::{batch_all_on_ah, decode_ah_call};
+use clap::Parser as ClapParser;
+use std::fs;
+
+/// Combine Asset Hub calls into a single `Utility.batch_all` proposal.
+#[derive(Debug, ClapParser)]
+pub(crate) struct BatchAhArgs {
+	/// Network. Currently only `polkadot` is supported.
+	#[clap(long = "network", short, default_value = "polkadot")]
+	network: String,
+
+	/// Output file for the batched AH proposal (hex-encoded).
+	#[clap(long = "output", short, default_value = "proposal.call")]
+	output: String,
+
+	/// Input files, each containing a hex-encoded Asset Hub call.
+	/// The calls are batched in the order provided.
+	#[clap(required = true)]
+	inputs: Vec<String>,
+}
+
+pub(crate) async fn batch_ah(args: BatchAhArgs) {
+	if args.network.to_ascii_lowercase() != "polkadot" {
+		panic!("Only `--network polkadot` is supported for now.");
+	}
+
+	let mut calls = Vec::with_capacity(args.inputs.len());
+	for path in &args.inputs {
+		let hex_str = fs::read_to_string(path)
+			.unwrap_or_else(|e| panic!("read {path}: {e}"))
+			.trim()
+			.to_string();
+		let bytes = hex::decode(hex_str.trim_start_matches("0x"))
+			.unwrap_or_else(|e| panic!("decode hex in {path}: {e}"));
+		let call = decode_ah_call(&bytes)
+			.unwrap_or_else(|e| panic!("decode AH call in {path}: {e}"));
+		calls.push(call);
+	}
+
+	let proposal = batch_all_on_ah(calls);
+
+	let mut hex_out = "0x".to_owned();
+	hex_out.push_str(&hex::encode(&proposal.encoded));
+	fs::write(&args.output, &hex_out).expect("write proposal output");
+
+	println!("Batched Asset Hub proposal:");
+	println!("  Inner calls: {}", args.inputs.len());
+	for input in &args.inputs {
+		println!("    - {input}");
+	}
+	println!("  Proposal size: {} bytes", proposal.length);
+	println!("  Written to: {}", args.output);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod functions;
 use crate::functions::*;
 mod build_upgrade;
 use crate::build_upgrade::{build_upgrade, UpgradeArgs};
+mod register_system_para;
+use crate::register_system_para::{register_system_para, RegisterSystemParaArgs};
 mod submit_referendum;
 use crate::submit_referendum::{submit_referendum, ReferendumArgs};
 use clap::Parser as ClapParser;
@@ -15,6 +17,7 @@ mod tests;
 #[derive(Debug, ClapParser)]
 enum Command {
 	BuildUpgrade(UpgradeArgs),
+	RegisterSystemPara(RegisterSystemParaArgs),
 	SubmitReferendum(ReferendumArgs),
 }
 
@@ -23,6 +26,7 @@ async fn main() {
 	let args = Command::parse();
 	match args {
 		Command::BuildUpgrade(prefs) => build_upgrade(prefs).await,
+		Command::RegisterSystemPara(prefs) => register_system_para(prefs).await,
 		Command::SubmitReferendum(prefs) => submit_referendum(prefs).await,
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,19 @@ mod types;
 use crate::types::*;
 mod functions;
 use crate::functions::*;
+mod primitives;
 mod build_upgrade;
 use crate::build_upgrade::{build_upgrade, UpgradeArgs};
 mod register_system_para;
 use crate::register_system_para::{register_system_para, RegisterSystemParaArgs};
 mod submit_referendum;
 use crate::submit_referendum::{submit_referendum, ReferendumArgs};
+mod batch_ah;
+use crate::batch_ah::{batch_ah, BatchAhArgs};
+mod xcm_force_register;
+use crate::xcm_force_register::{xcm_force_register, XcmForceRegisterArgs};
+mod xcm_force_reserve;
+use crate::xcm_force_reserve::{xcm_force_reserve, XcmForceReserveArgs};
 use clap::Parser as ClapParser;
 
 #[cfg(test)]
@@ -19,6 +26,9 @@ enum Command {
 	BuildUpgrade(UpgradeArgs),
 	RegisterSystemPara(RegisterSystemParaArgs),
 	SubmitReferendum(ReferendumArgs),
+	XcmForceRegister(XcmForceRegisterArgs),
+	XcmForceReserve(XcmForceReserveArgs),
+	BatchAh(BatchAhArgs),
 }
 
 #[tokio::main]
@@ -28,5 +38,8 @@ async fn main() {
 		Command::BuildUpgrade(prefs) => build_upgrade(prefs).await,
 		Command::RegisterSystemPara(prefs) => register_system_para(prefs).await,
 		Command::SubmitReferendum(prefs) => submit_referendum(prefs).await,
+		Command::XcmForceRegister(prefs) => xcm_force_register(prefs).await,
+		Command::XcmForceReserve(prefs) => xcm_force_reserve(prefs).await,
+		Command::BatchAh(prefs) => batch_ah(prefs).await,
 	}
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,0 +1,180 @@
+//! Reusable building blocks for constructing Asset Hub governance proposals.
+//!
+//! Each function produces a `CallInfo` for a specific encoded runtime call on one of
+//! the supported chains. Higher-level commands (e.g. `register-system-para`) compose
+//! these primitives into complete proposals.
+//!
+//! The public primitives here drive three CLI subcommands:
+//! - `xcm-force-reserve` wraps [`build_force_reserve_call`] in an AH→Coretime XCM send.
+//! - `xcm-force-register` builds [`build_force_register_call`] as a preimage and wraps
+//!   the whitelist + dispatch pair in AH→Relay XCM sends.
+//! - `batch-ah` combines multiple AH-level call files via [`batch_all_on_ah`].
+
+use crate::*;
+
+/// Destination chain for an XCM sent from Asset Hub.
+pub(crate) enum XcmDest {
+	/// Relay chain (parent, `Location { parents: 1, interior: Here }`).
+	Relay,
+	/// Sibling parachain by ID (`Location { parents: 1, interior: X1(Parachain(id)) }`).
+	Sibling(u32),
+}
+
+/// Parameters for `Registrar.force_register` on the relay chain.
+pub(crate) struct ForceRegisterParams {
+	pub wasm_bytes: Vec<u8>,
+	pub genesis_head_bytes: Vec<u8>,
+	pub para_id: u32,
+	pub manager_bytes: [u8; 32],
+	pub deposit: u128,
+}
+
+/// Build a relay chain `Registrar.force_register` call.
+///
+/// Returns the encoded relay `RuntimeCall`, ready to be stored as a preimage or
+/// wrapped in the whitelist pattern.
+pub(crate) fn build_force_register_call(params: ForceRegisterParams) -> CallInfo {
+	use polkadot_relay::runtime_types::{
+		polkadot_parachain_primitives::primitives::{HeadData, Id, ValidationCode},
+		polkadot_runtime_common::paras_registrar::pallet::Call as RegistrarCall,
+	};
+
+	let call = PolkadotRuntimeCall::Registrar(RegistrarCall::force_register {
+		who: subxt::utils::AccountId32(params.manager_bytes),
+		deposit: params.deposit,
+		id: Id(params.para_id),
+		genesis_head: HeadData(params.genesis_head_bytes),
+		validation_code: ValidationCode(params.wasm_bytes),
+	});
+	CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(call))
+}
+
+/// Build a relay chain `Whitelist.whitelist_call(hash)` call.
+pub(crate) fn build_whitelist_call(call_hash: [u8; 32]) -> CallInfo {
+	use polkadot_relay::runtime_types::pallet_whitelist::pallet::Call as WhitelistCall;
+	let call = PolkadotRuntimeCall::Whitelist(WhitelistCall::whitelist_call {
+		call_hash: H256(call_hash),
+	});
+	CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(call))
+}
+
+/// Build a relay chain `Whitelist.dispatch_whitelisted_call(hash, len, weight)` call.
+///
+/// Returns the `RuntimeCall` itself (not `CallInfo`) so it can optionally be wrapped
+/// in `Scheduler.schedule_after` via [`wrap_in_relay_scheduler`] before encoding.
+pub(crate) fn build_dispatch_whitelisted_call(
+	call_hash: [u8; 32],
+	call_encoded_len: u32,
+	ref_time: u64,
+	proof_size: u64,
+) -> PolkadotRuntimeCall {
+	use polkadot_relay::runtime_types::{
+		pallet_whitelist::pallet::Call as WhitelistCall, sp_weights::weight_v2::Weight,
+	};
+	PolkadotRuntimeCall::Whitelist(WhitelistCall::dispatch_whitelisted_call {
+		call_hash: H256(call_hash),
+		call_encoded_len,
+		call_weight_witness: Weight { ref_time, proof_size },
+	})
+}
+
+/// Wrap a relay chain call in `Scheduler.schedule_after(delay, call)` with priority 0.
+///
+/// Used for the free-preimage path: `whitelist_call` runs immediately (marking the
+/// preimage hash as requested), then the dispatch is delayed to give time to note the
+/// preimage for free.
+pub(crate) fn wrap_in_relay_scheduler(
+	call: PolkadotRuntimeCall,
+	delay: u32,
+) -> PolkadotRuntimeCall {
+	use polkadot_relay::runtime_types::pallet_scheduler::pallet::Call as SchedulerCall;
+	PolkadotRuntimeCall::Scheduler(SchedulerCall::schedule_after {
+		after: delay,
+		maybe_periodic: None,
+		priority: 0,
+		call: Box::new(call),
+	})
+}
+
+/// Build a Coretime chain `Broker.force_reserve(workload, core)` call reserving
+/// a complete core mask for the given task (parachain ID).
+pub(crate) fn build_force_reserve_call(para_id: u32, core: u16) -> CallInfo {
+	use polkadot_coretime::runtime_types::{
+		bounded_collections::bounded_vec::BoundedVec,
+		pallet_broker::{
+			core_mask::CoreMask, coretime_interface::CoreAssignment, pallet::Call as BrokerCall,
+			types::ScheduleItem,
+		},
+	};
+
+	// CoreMask::complete() = all 80 bits set = 0xffffffffffffffffffff
+	let complete_mask = CoreMask([0xff; 10]);
+	let call = PolkadotCoretimeRuntimeCall::Broker(BrokerCall::force_reserve {
+		workload: BoundedVec(vec![ScheduleItem {
+			mask: complete_mask,
+			assignment: CoreAssignment::Task(para_id),
+		}]),
+		core,
+	});
+	CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotCoretime(call))
+}
+
+/// Wrap an encoded runtime call in an AH `PolkadotXcm.send(dest, Xcm([UnpaidExecution,
+/// Transact(Superuser, inner_call_bytes), ExpectTransactStatus(Success)]))`.
+///
+/// The `inner_call_bytes` are the SCALE-encoded `RuntimeCall` on the destination chain.
+pub(crate) fn wrap_in_xcm_send_from_ah(
+	dest: XcmDest,
+	inner_call_bytes: Vec<u8>,
+) -> PolkadotAssetHubRuntimeCall {
+	use polkadot_asset_hub::runtime_types::{
+		pallet_xcm::pallet::Call as XcmCall,
+		staging_xcm::v5::{
+			junction::Junction::Parachain, junctions::Junctions::Here,
+			junctions::Junctions::X1, location::Location, Instruction, Xcm,
+		},
+		xcm::{
+			double_encoded::DoubleEncoded, v3::MaybeErrorCode, v3::OriginKind, v3::WeightLimit,
+			VersionedLocation, VersionedXcm::V5,
+		},
+	};
+
+	let dest_location = match dest {
+		XcmDest::Relay => Location { parents: 1, interior: Here },
+		XcmDest::Sibling(id) => Location { parents: 1, interior: X1([Parachain(id)]) },
+	};
+
+	PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
+		dest: Box::new(VersionedLocation::V5(dest_location)),
+		message: Box::new(V5(Xcm(vec![
+			Instruction::UnpaidExecution {
+				weight_limit: WeightLimit::Unlimited,
+				check_origin: None,
+			},
+			Instruction::Transact {
+				origin_kind: OriginKind::Superuser,
+				fallback_max_weight: None,
+				call: DoubleEncoded { encoded: inner_call_bytes },
+			},
+			Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
+		]))),
+	})
+}
+
+/// Wrap a list of Asset Hub calls in `Utility.batch_all`.
+///
+/// Used to compose multiple primitive XCM sends into a single proposal.
+pub(crate) fn batch_all_on_ah(calls: Vec<PolkadotAssetHubRuntimeCall>) -> CallInfo {
+	use polkadot_asset_hub::runtime_types::pallet_utility::pallet::Call as UtilityCall;
+	let batch = PolkadotAssetHubRuntimeCall::Utility(UtilityCall::batch_all { calls });
+	CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(batch))
+}
+
+/// Decode an Asset Hub runtime call from its SCALE-encoded bytes.
+///
+/// Used by `batch-ah` to read input files and reassemble the calls for batching.
+pub(crate) fn decode_ah_call(bytes: &[u8]) -> Result<PolkadotAssetHubRuntimeCall, String> {
+	use parity_scale_codec::Decode;
+	PolkadotAssetHubRuntimeCall::decode(&mut &bytes[..])
+		.map_err(|e| format!("Failed to decode Asset Hub call: {e}"))
+}

--- a/src/register_system_para.rs
+++ b/src/register_system_para.rs
@@ -52,6 +52,12 @@ pub(crate) struct RegisterSystemParaArgs {
 	#[clap(long = "assign-core")]
 	assign_core: Option<u16>,
 
+	/// Delay dispatch_whitelisted_call using Scheduler.schedule_after so that the preimage
+	/// can be noted for free after whitelist_call requests it. Value is the delay in relay
+	/// chain blocks (e.g. 100 = ~10 minutes on Polkadot).
+	#[clap(long = "delay-whitelist-dispatch-relay")]
+	delay_whitelist_dispatch_relay: Option<u32>,
+
 	/// Output file name for the Asset Hub proposal.
 	#[clap(long = "filename")]
 	filename: Option<String>,
@@ -68,6 +74,9 @@ pub(crate) struct RegisterSystemParaParams {
 	pub proof_size: u64,
 	/// If set, reserve this core index for the para via broker.force_reserve on the Coretime chain.
 	pub assign_core: Option<u16>,
+	/// If set, wrap dispatch_whitelisted_call in Scheduler.schedule_after with this delay (blocks).
+	/// This allows the preimage to be noted for free after whitelist_call requests it.
+	pub delay_whitelist_dispatch_relay: Option<u32>,
 }
 
 /// Output of building registration calls.
@@ -123,8 +132,23 @@ pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) ->
 				proof_size: params.proof_size,
 			},
 		});
+
+	// Optionally wrap dispatch in Scheduler.schedule_after for the free preimage path:
+	// whitelist_call runs immediately (requesting the preimage hash), then dispatch
+	// is delayed by N blocks, giving time to note the preimage for free.
+	let dispatch_relay_call = if let Some(delay) = params.delay_whitelist_dispatch_relay {
+		use polkadot_relay::runtime_types::pallet_scheduler::pallet::Call as SchedulerCall;
+		PolkadotRuntimeCall::Scheduler(SchedulerCall::schedule_after {
+			after: delay,
+			maybe_periodic: None,
+			priority: 0,
+			call: Box::new(dispatch_whitelisted_call),
+		})
+	} else {
+		dispatch_whitelisted_call
+	};
 	let dispatch_info =
-		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_whitelisted_call));
+		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_relay_call));
 
 	// 3. Wrap in XCM send calls (Asset Hub → Relay / Coretime)
 	use polkadot_asset_hub::runtime_types::staging_xcm::v5::junction::Junction::Parachain;
@@ -263,6 +287,9 @@ async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
 	if let Some(core) = args.assign_core {
 		println!("Assign core: {} (via broker.force_reserve on Coretime chain)", core);
 	}
+	if let Some(delay) = args.delay_whitelist_dispatch_relay {
+		println!("Free preimage: dispatch delayed by {} blocks (~{} minutes)", delay, delay * 6 / 60);
+	}
 
 	// Build calls
 	let output = build_polkadot_register_calls(RegisterSystemParaParams {
@@ -274,6 +301,7 @@ async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
 		ref_time: args.ref_time,
 		proof_size: args.proof_size,
 		assign_core: args.assign_core,
+		delay_whitelist_dispatch_relay: args.delay_whitelist_dispatch_relay,
 	});
 
 	println!("\nforce_register call:");

--- a/src/register_system_para.rs
+++ b/src/register_system_para.rs
@@ -1,0 +1,247 @@
+use crate::*;
+use clap::Parser as ClapParser;
+use std::fs;
+
+/// Generate the calls needed to register a system parachain via Asset Hub governance.
+///
+/// Produces:
+///   - A `force_register_call.hex` file with raw preimage bytes for the relay chain
+///   - A proposal file with a batched Asset Hub call: `utility.batch_all([xcm_whitelist, xcm_dispatch])`
+///
+/// The proposal uses the whitelist+preimage pattern to work around the 128 KB UMP limit.
+/// Asset Hub has Root on the relay chain via LocationAsSuperuser, so the XCM Transacts
+/// execute whitelist.whitelist_call and whitelist.dispatch_whitelisted_call with Root origin.
+#[derive(Debug, ClapParser)]
+pub(crate) struct RegisterSystemParaArgs {
+	/// Path to the WASM validation code file.
+	#[clap(long = "wasm")]
+	wasm: String,
+
+	/// Path to the genesis head hex file (from: polkadot-omni-node export-genesis-head).
+	#[clap(long = "genesis-head")]
+	genesis_head: String,
+
+	/// Parachain ID to register.
+	#[clap(long = "para-id")]
+	para_id: u32,
+
+	/// Network. Currently only `polkadot` is supported.
+	#[clap(long = "network", short)]
+	network: String,
+
+	/// Manager account SS58 address.
+	#[clap(long = "manager")]
+	manager: String,
+
+	/// Deposit in plancks.
+	#[clap(long = "deposit", default_value = "0")]
+	deposit: u128,
+
+	/// Weight ref_time witness for dispatch_whitelisted_call.
+	#[clap(long = "ref-time", default_value = "60000000000")]
+	ref_time: u64,
+
+	/// Weight proof_size witness for dispatch_whitelisted_call.
+	#[clap(long = "proof-size", default_value = "10000")]
+	proof_size: u64,
+
+	/// Output file name for the Asset Hub proposal.
+	#[clap(long = "filename")]
+	filename: Option<String>,
+}
+
+/// Parameters for building registration calls (decoupled from CLI/file I/O).
+pub(crate) struct RegisterSystemParaParams {
+	pub wasm_bytes: Vec<u8>,
+	pub genesis_head_bytes: Vec<u8>,
+	pub para_id: u32,
+	pub manager_bytes: [u8; 32],
+	pub deposit: u128,
+	pub ref_time: u64,
+	pub proof_size: u64,
+}
+
+/// Output of building registration calls.
+pub(crate) struct RegisterSystemParaOutput {
+	/// The encoded force_register call (relay chain). Used as preimage content.
+	pub force_register_info: CallInfo,
+	/// The batched Asset Hub proposal (utility.batch_all with two XCM sends).
+	pub proposal: CallInfo,
+}
+
+/// Build the registration calls from parameters (pure logic, no file I/O).
+pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) -> RegisterSystemParaOutput {
+	use polkadot_asset_hub::runtime_types::{
+		pallet_utility::pallet::Call as UtilityCall,
+		pallet_xcm::pallet::Call as XcmCall,
+		staging_xcm::v5::{junctions::Junctions::Here, location::Location, Instruction, Xcm},
+		xcm::{
+			double_encoded::DoubleEncoded, v3::OriginKind, v3::WeightLimit, VersionedLocation,
+			VersionedXcm::V5,
+		},
+	};
+	use polkadot_relay::runtime_types::{
+		polkadot_parachain_primitives::primitives::{HeadData, Id, ValidationCode},
+		polkadot_runtime_common::paras_registrar::pallet::Call as RegistrarCall,
+		pallet_whitelist::pallet::Call as WhitelistCall,
+		sp_weights::weight_v2::Weight,
+	};
+
+	// 1. Encode force_register call (relay chain)
+	let force_register_call = PolkadotRuntimeCall::Registrar(RegistrarCall::force_register {
+		who: subxt::utils::AccountId32(params.manager_bytes),
+		deposit: params.deposit,
+		id: Id(params.para_id),
+		genesis_head: HeadData(params.genesis_head_bytes),
+		validation_code: ValidationCode(params.wasm_bytes),
+	});
+
+	let force_register_info =
+		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(force_register_call));
+
+	// 2. Encode whitelist calls (relay chain, for XCM Transact)
+	let whitelist_call = PolkadotRuntimeCall::Whitelist(WhitelistCall::whitelist_call {
+		call_hash: H256(force_register_info.hash),
+	});
+	let whitelist_info = CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(whitelist_call));
+
+	let dispatch_whitelisted_call =
+		PolkadotRuntimeCall::Whitelist(WhitelistCall::dispatch_whitelisted_call {
+			call_hash: H256(force_register_info.hash),
+			call_encoded_len: force_register_info.length,
+			call_weight_witness: Weight {
+				ref_time: params.ref_time,
+				proof_size: params.proof_size,
+			},
+		});
+	let dispatch_info =
+		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_whitelisted_call));
+
+	// 3. Wrap in XCM send calls (Asset Hub → Relay)
+	let relay_dest = Box::new(VersionedLocation::V5(Location {
+		parents: 1,
+		interior: Here,
+	}));
+
+	let xcm_whitelist = PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
+		dest: relay_dest.clone(),
+		message: Box::new(V5(Xcm(vec![
+			Instruction::UnpaidExecution {
+				weight_limit: WeightLimit::Unlimited,
+				check_origin: None,
+			},
+			Instruction::Transact {
+				origin_kind: OriginKind::Superuser,
+				fallback_max_weight: None,
+				call: DoubleEncoded { encoded: whitelist_info.encoded },
+			},
+		]))),
+	});
+
+	let xcm_dispatch = PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
+		dest: relay_dest,
+		message: Box::new(V5(Xcm(vec![
+			Instruction::UnpaidExecution {
+				weight_limit: WeightLimit::Unlimited,
+				check_origin: None,
+			},
+			Instruction::Transact {
+				origin_kind: OriginKind::Superuser,
+				fallback_max_weight: None,
+				call: DoubleEncoded { encoded: dispatch_info.encoded },
+			},
+		]))),
+	});
+
+	// 4. Batch into single proposal
+	let batch_call = PolkadotAssetHubRuntimeCall::Utility(UtilityCall::batch_all {
+		calls: vec![xcm_whitelist, xcm_dispatch],
+	});
+
+	let proposal = CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(batch_call));
+
+	RegisterSystemParaOutput { force_register_info, proposal }
+}
+
+pub(crate) async fn register_system_para(args: RegisterSystemParaArgs) {
+	match args.network.to_ascii_lowercase().as_str() {
+		"polkadot" => register_polkadot_system_para(args).await,
+		"kusama" => {
+			panic!("Kusama support not yet implemented. Use --network polkadot.");
+		},
+		_ => panic!("`network` must be `polkadot` or `kusama`"),
+	}
+}
+
+async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
+	// Read inputs
+	let wasm_bytes = fs::read(&args.wasm).expect("Should read WASM file");
+	println!("WASM size: {} bytes", wasm_bytes.len());
+
+	let genesis_head_hex = fs::read_to_string(&args.genesis_head)
+		.expect("Should read genesis head file")
+		.trim()
+		.to_string();
+	let genesis_head_bytes =
+		hex::decode(genesis_head_hex.trim_start_matches("0x")).expect("Valid hex for genesis head");
+	println!("Genesis head size: {} bytes", genesis_head_bytes.len());
+
+	use sp_core::crypto::Ss58Codec;
+	let manager_account =
+		sp_core::crypto::AccountId32::from_ss58check(&args.manager).expect("Valid SS58 address");
+	let manager_bytes: [u8; 32] = manager_account.into();
+
+	println!("ParaId: {}", args.para_id);
+	println!("Manager: {}", args.manager);
+	println!("Deposit: {}", args.deposit);
+
+	// Build calls
+	let output = build_polkadot_register_calls(RegisterSystemParaParams {
+		wasm_bytes,
+		genesis_head_bytes,
+		para_id: args.para_id,
+		manager_bytes,
+		deposit: args.deposit,
+		ref_time: args.ref_time,
+		proof_size: args.proof_size,
+	});
+
+	println!("\nforce_register call:");
+	println!("  Encoded size: {} bytes", output.force_register_info.length);
+	println!("  Hash: 0x{}", hex::encode(output.force_register_info.hash));
+
+	// Write raw preimage bytes
+	let mut preimage_hex = "0x".to_owned();
+	preimage_hex.push_str(&hex::encode(&output.force_register_info.encoded));
+	fs::write("force_register_call.hex", &preimage_hex).expect("write force_register_call.hex");
+	println!("  Written to: force_register_call.hex");
+
+	println!("\nWhitelist+dispatch wrapped in XCM batch:");
+	println!("  Proposal size: {} bytes", output.proposal.length);
+
+	let fname = args.filename.unwrap_or_else(|| {
+		format!("register-system-para-{}.call", args.para_id)
+	});
+
+	let mut proposal_hex = "0x".to_owned();
+	proposal_hex.push_str(&hex::encode(&output.proposal.encoded));
+	fs::write(&fname, &proposal_hex).expect("write proposal file");
+
+	// Output summary
+	println!("\n{}", "=".repeat(60));
+	println!("  REGISTER SYSTEM PARACHAIN {}", args.para_id);
+	println!("{}", "=".repeat(60));
+	println!();
+	println!("  STEP 1 — Submit on Relay Chain (permissionless):");
+	println!(
+		"    Use force_register_call.hex ({} bytes) as the bytes for",
+		output.force_register_info.length
+	);
+	println!("    Preimage.note_preimage in any wallet (e.g. Polkadot JS Apps).");
+	println!();
+	println!("  STEP 2 — Submit as referendum:");
+	println!("    opengov-cli submit-referendum \\");
+	println!("      --proposal \"{}\" \\", fname);
+	println!("      --network \"polkadot\" --track whitelistedcaller");
+	println!("{}", "=".repeat(60));
+}

--- a/src/register_system_para.rs
+++ b/src/register_system_para.rs
@@ -83,173 +83,68 @@ pub(crate) struct RegisterSystemParaParams {
 pub(crate) struct RegisterSystemParaOutput {
 	/// The encoded force_register call (relay chain). Used as preimage content.
 	pub force_register_info: CallInfo,
-	/// The batched Asset Hub proposal (utility.batch_all with two XCM sends).
+	/// The batched Asset Hub proposal (utility.batch_all with two or three XCM sends).
 	pub proposal: CallInfo,
+	/// The encoded force_reserve call (coretime chain), if --assign-core was used.
+	pub force_reserve_info: Option<CallInfo>,
 }
 
 /// Build the registration calls from parameters (pure logic, no file I/O).
+///
+/// Composes primitives from the `primitives` module:
+/// 1. `force_register` (relay)
+/// 2. `whitelist_call(hash)` wrapped in XCM from AH → Relay
+/// 3. `dispatch_whitelisted_call(hash, len, weight)` optionally wrapped in Scheduler, then XCM
+/// 4. Optional `force_reserve(para_id, core)` wrapped in XCM from AH → Coretime
+/// 5. All AH calls batched via `Utility.batch_all`
 pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) -> RegisterSystemParaOutput {
-	use polkadot_asset_hub::runtime_types::{
-		pallet_utility::pallet::Call as UtilityCall,
-		pallet_xcm::pallet::Call as XcmCall,
-		staging_xcm::v5::{junctions::Junctions::Here, location::Location, Instruction, Xcm},
-		xcm::{
-			double_encoded::DoubleEncoded, v3::MaybeErrorCode, v3::OriginKind, v3::WeightLimit,
-			VersionedLocation, VersionedXcm::V5,
-		},
-	};
-	use polkadot_relay::runtime_types::{
-		polkadot_parachain_primitives::primitives::{HeadData, Id, ValidationCode},
-		polkadot_runtime_common::paras_registrar::pallet::Call as RegistrarCall,
-		pallet_whitelist::pallet::Call as WhitelistCall,
-		sp_weights::weight_v2::Weight,
+	use crate::primitives::{
+		batch_all_on_ah, build_dispatch_whitelisted_call, build_force_register_call,
+		build_force_reserve_call, build_whitelist_call, wrap_in_relay_scheduler,
+		wrap_in_xcm_send_from_ah, ForceRegisterParams, XcmDest,
 	};
 
-	// 1. Encode force_register call (relay chain)
-	let force_register_call = PolkadotRuntimeCall::Registrar(RegistrarCall::force_register {
-		who: subxt::utils::AccountId32(params.manager_bytes),
+	// 1. Relay force_register (preimage content)
+	let force_register_info = build_force_register_call(ForceRegisterParams {
+		wasm_bytes: params.wasm_bytes,
+		genesis_head_bytes: params.genesis_head_bytes,
+		para_id: params.para_id,
+		manager_bytes: params.manager_bytes,
 		deposit: params.deposit,
-		id: Id(params.para_id),
-		genesis_head: HeadData(params.genesis_head_bytes),
-		validation_code: ValidationCode(params.wasm_bytes),
 	});
 
-	let force_register_info =
-		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(force_register_call));
+	// 2. whitelist_call(hash) + XCM wrap
+	let whitelist_info = build_whitelist_call(force_register_info.hash);
+	let xcm_whitelist = wrap_in_xcm_send_from_ah(XcmDest::Relay, whitelist_info.encoded);
 
-	// 2. Encode whitelist calls (relay chain, for XCM Transact)
-	let whitelist_call = PolkadotRuntimeCall::Whitelist(WhitelistCall::whitelist_call {
-		call_hash: H256(force_register_info.hash),
-	});
-	let whitelist_info = CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(whitelist_call));
-
-	let dispatch_whitelisted_call =
-		PolkadotRuntimeCall::Whitelist(WhitelistCall::dispatch_whitelisted_call {
-			call_hash: H256(force_register_info.hash),
-			call_encoded_len: force_register_info.length,
-			call_weight_witness: Weight {
-				ref_time: params.ref_time,
-				proof_size: params.proof_size,
-			},
-		});
-
-	// Optionally wrap dispatch in Scheduler.schedule_after for the free preimage path:
-	// whitelist_call runs immediately (requesting the preimage hash), then dispatch
-	// is delayed by N blocks, giving time to note the preimage for free.
-	let dispatch_relay_call = if let Some(delay) = params.delay_whitelist_dispatch_relay {
-		use polkadot_relay::runtime_types::pallet_scheduler::pallet::Call as SchedulerCall;
-		PolkadotRuntimeCall::Scheduler(SchedulerCall::schedule_after {
-			after: delay,
-			maybe_periodic: None,
-			priority: 0,
-			call: Box::new(dispatch_whitelisted_call),
-		})
-	} else {
-		dispatch_whitelisted_call
+	// 3. dispatch_whitelisted_call(hash, len, weight), optional Scheduler wrap, then XCM wrap
+	let dispatch_call = build_dispatch_whitelisted_call(
+		force_register_info.hash,
+		force_register_info.length,
+		params.ref_time,
+		params.proof_size,
+	);
+	let dispatch_call = match params.delay_whitelist_dispatch_relay {
+		Some(delay) => wrap_in_relay_scheduler(dispatch_call, delay),
+		None => dispatch_call,
 	};
-	let dispatch_info =
-		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_relay_call));
+	let dispatch_info = CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_call));
+	let xcm_dispatch = wrap_in_xcm_send_from_ah(XcmDest::Relay, dispatch_info.encoded);
 
-	// 3. Wrap in XCM send calls (Asset Hub → Relay / Coretime)
-	use polkadot_asset_hub::runtime_types::staging_xcm::v5::junction::Junction::Parachain;
-	use polkadot_asset_hub::runtime_types::staging_xcm::v5::junctions::Junctions::X1;
-
-	let relay_dest = Box::new(VersionedLocation::V5(Location {
-		parents: 1,
-		interior: Here,
-	}));
-
-	let xcm_whitelist = PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
-		dest: relay_dest.clone(),
-		message: Box::new(V5(Xcm(vec![
-			Instruction::UnpaidExecution {
-				weight_limit: WeightLimit::Unlimited,
-				check_origin: None,
-			},
-			Instruction::Transact {
-				origin_kind: OriginKind::Superuser,
-				fallback_max_weight: None,
-				call: DoubleEncoded { encoded: whitelist_info.encoded },
-			},
-			Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
-		]))),
-	});
-
-	let xcm_dispatch = PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
-		dest: relay_dest,
-		message: Box::new(V5(Xcm(vec![
-			Instruction::UnpaidExecution {
-				weight_limit: WeightLimit::Unlimited,
-				check_origin: None,
-			},
-			Instruction::Transact {
-				origin_kind: OriginKind::Superuser,
-				fallback_max_weight: None,
-				call: DoubleEncoded { encoded: dispatch_info.encoded },
-			},
-			Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
-		]))),
-	});
-
-	// 4. Optionally add XCM to Coretime chain for force_reserve
+	// 4. Optional force_reserve on Coretime via XCM
 	let mut batch_calls = vec![xcm_whitelist, xcm_dispatch];
-
-	if let Some(core_index) = params.assign_core {
-		use polkadot_coretime::runtime_types::{
-			bounded_collections::bounded_vec::BoundedVec,
-			pallet_broker::pallet::Call as BrokerCall,
-			pallet_broker::types::ScheduleItem,
-			pallet_broker::core_mask::CoreMask,
-			pallet_broker::coretime_interface::CoreAssignment as CoretimeCoreAssignment,
-		};
-
-		// Encode broker.force_reserve using Coretime chain types
-		// CoreMask::complete() = all 80 bits set = 0xffffffffffffffffffff
-		let complete_mask = CoreMask([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-		let force_reserve_call =
-			PolkadotCoretimeRuntimeCall::Broker(BrokerCall::force_reserve {
-				workload: BoundedVec(vec![ScheduleItem {
-					mask: complete_mask,
-					assignment: CoretimeCoreAssignment::Task(params.para_id),
-				}]),
-				core: core_index,
-			});
-		let force_reserve_info =
-			CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotCoretime(force_reserve_call));
-
-		// XCM from Asset Hub → Coretime chain (sibling, Parachain 1005)
-		let coretime_dest = Box::new(VersionedLocation::V5(Location {
-			parents: 1,
-			interior: X1([Parachain(1005)]),
-		}));
-
-		let xcm_force_reserve = PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
-			dest: coretime_dest,
-			message: Box::new(V5(Xcm(vec![
-				Instruction::UnpaidExecution {
-					weight_limit: WeightLimit::Unlimited,
-					check_origin: None,
-				},
-				Instruction::Transact {
-					origin_kind: OriginKind::Superuser,
-					fallback_max_weight: None,
-					call: DoubleEncoded { encoded: force_reserve_info.encoded },
-				},
-				Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
-			]))),
-		});
-
+	let force_reserve_info = params.assign_core.map(|core| {
+		let fr_info = build_force_reserve_call(params.para_id, core);
+		let xcm_force_reserve =
+			wrap_in_xcm_send_from_ah(XcmDest::Sibling(1005), fr_info.encoded.clone());
 		batch_calls.push(xcm_force_reserve);
-	}
-
-	// 5. Batch into single proposal
-	let batch_call = PolkadotAssetHubRuntimeCall::Utility(UtilityCall::batch_all {
-		calls: batch_calls,
+		fr_info
 	});
 
-	let proposal = CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(batch_call));
+	// 5. Batch into single Asset Hub proposal
+	let proposal = batch_all_on_ah(batch_calls);
 
-	RegisterSystemParaOutput { force_register_info, proposal }
+	RegisterSystemParaOutput { force_register_info, proposal, force_reserve_info }
 }
 
 pub(crate) async fn register_system_para(args: RegisterSystemParaArgs) {
@@ -313,6 +208,13 @@ async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
 	preimage_hex.push_str(&hex::encode(&output.force_register_info.encoded));
 	fs::write("force_register_call.hex", &preimage_hex).expect("write force_register_call.hex");
 	println!("  Written to: force_register_call.hex");
+
+	if let Some(ref fr) = output.force_reserve_info {
+		let mut fr_hex = "0x".to_owned();
+		fr_hex.push_str(&hex::encode(&fr.encoded));
+		fs::write("force_reserve_call.hex", &fr_hex).expect("write force_reserve_call.hex");
+		println!("  force_reserve call written to: force_reserve_call.hex ({} bytes)", fr.length);
+	}
 
 	println!("\nWhitelist+dispatch wrapped in XCM batch:");
 	println!("  Proposal size: {} bytes", output.proposal.length);

--- a/src/register_system_para.rs
+++ b/src/register_system_para.rs
@@ -38,12 +38,19 @@ pub(crate) struct RegisterSystemParaArgs {
 	deposit: u128,
 
 	/// Weight ref_time witness for dispatch_whitelisted_call.
-	#[clap(long = "ref-time", default_value = "60000000000")]
+	/// Default based on Polkadot benchmarks for force_register (~7.7B) with headroom.
+	#[clap(long = "ref-time", default_value = "10000000000")]
 	ref_time: u64,
 
 	/// Weight proof_size witness for dispatch_whitelisted_call.
-	#[clap(long = "proof-size", default_value = "10000")]
+	/// Default based on Polkadot benchmarks for force_register (~3697) with headroom.
+	#[clap(long = "proof-size", default_value = "5000")]
 	proof_size: u64,
+
+	/// Reserve a dedicated core for this parachain on the Coretime chain via broker.force_reserve.
+	/// Provide the core index. Sent as XCM from Asset Hub to the Coretime chain.
+	#[clap(long = "assign-core")]
+	assign_core: Option<u16>,
 
 	/// Output file name for the Asset Hub proposal.
 	#[clap(long = "filename")]
@@ -59,6 +66,8 @@ pub(crate) struct RegisterSystemParaParams {
 	pub deposit: u128,
 	pub ref_time: u64,
 	pub proof_size: u64,
+	/// If set, reserve this core index for the para via broker.force_reserve on the Coretime chain.
+	pub assign_core: Option<u16>,
 }
 
 /// Output of building registration calls.
@@ -117,7 +126,10 @@ pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) ->
 	let dispatch_info =
 		CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_whitelisted_call));
 
-	// 3. Wrap in XCM send calls (Asset Hub → Relay)
+	// 3. Wrap in XCM send calls (Asset Hub → Relay / Coretime)
+	use polkadot_asset_hub::runtime_types::staging_xcm::v5::junction::Junction::Parachain;
+	use polkadot_asset_hub::runtime_types::staging_xcm::v5::junctions::Junctions::X1;
+
 	let relay_dest = Box::new(VersionedLocation::V5(Location {
 		parents: 1,
 		interior: Here,
@@ -155,9 +167,60 @@ pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) ->
 		]))),
 	});
 
-	// 4. Batch into single proposal
+	// 4. Optionally add XCM to Coretime chain for force_reserve
+	let mut batch_calls = vec![xcm_whitelist, xcm_dispatch];
+
+	if let Some(core_index) = params.assign_core {
+		use polkadot_coretime::runtime_types::{
+			bounded_collections::bounded_vec::BoundedVec,
+			pallet_broker::pallet::Call as BrokerCall,
+			pallet_broker::types::ScheduleItem,
+			pallet_broker::core_mask::CoreMask,
+			pallet_broker::coretime_interface::CoreAssignment as CoretimeCoreAssignment,
+		};
+
+		// Encode broker.force_reserve using Coretime chain types
+		// CoreMask::complete() = all 80 bits set = 0xffffffffffffffffffff
+		let complete_mask = CoreMask([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+		let force_reserve_call =
+			PolkadotCoretimeRuntimeCall::Broker(BrokerCall::force_reserve {
+				workload: BoundedVec(vec![ScheduleItem {
+					mask: complete_mask,
+					assignment: CoretimeCoreAssignment::Task(params.para_id),
+				}]),
+				core: core_index,
+			});
+		let force_reserve_info =
+			CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotCoretime(force_reserve_call));
+
+		// XCM from Asset Hub → Coretime chain (sibling, Parachain 1005)
+		let coretime_dest = Box::new(VersionedLocation::V5(Location {
+			parents: 1,
+			interior: X1([Parachain(1005)]),
+		}));
+
+		let xcm_force_reserve = PolkadotAssetHubRuntimeCall::PolkadotXcm(XcmCall::send {
+			dest: coretime_dest,
+			message: Box::new(V5(Xcm(vec![
+				Instruction::UnpaidExecution {
+					weight_limit: WeightLimit::Unlimited,
+					check_origin: None,
+				},
+				Instruction::Transact {
+					origin_kind: OriginKind::Superuser,
+					fallback_max_weight: None,
+					call: DoubleEncoded { encoded: force_reserve_info.encoded },
+				},
+				Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
+			]))),
+		});
+
+		batch_calls.push(xcm_force_reserve);
+	}
+
+	// 5. Batch into single proposal
 	let batch_call = PolkadotAssetHubRuntimeCall::Utility(UtilityCall::batch_all {
-		calls: vec![xcm_whitelist, xcm_dispatch],
+		calls: batch_calls,
 	});
 
 	let proposal = CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(batch_call));
@@ -197,6 +260,10 @@ async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
 	println!("Manager: {}", args.manager);
 	println!("Deposit: {}", args.deposit);
 
+	if let Some(core) = args.assign_core {
+		println!("Assign core: {} (via broker.force_reserve on Coretime chain)", core);
+	}
+
 	// Build calls
 	let output = build_polkadot_register_calls(RegisterSystemParaParams {
 		wasm_bytes,
@@ -206,6 +273,7 @@ async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
 		deposit: args.deposit,
 		ref_time: args.ref_time,
 		proof_size: args.proof_size,
+		assign_core: args.assign_core,
 	});
 
 	println!("\nforce_register call:");

--- a/src/register_system_para.rs
+++ b/src/register_system_para.rs
@@ -76,8 +76,8 @@ pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) ->
 		pallet_xcm::pallet::Call as XcmCall,
 		staging_xcm::v5::{junctions::Junctions::Here, location::Location, Instruction, Xcm},
 		xcm::{
-			double_encoded::DoubleEncoded, v3::OriginKind, v3::WeightLimit, VersionedLocation,
-			VersionedXcm::V5,
+			double_encoded::DoubleEncoded, v3::MaybeErrorCode, v3::OriginKind, v3::WeightLimit,
+			VersionedLocation, VersionedXcm::V5,
 		},
 	};
 	use polkadot_relay::runtime_types::{
@@ -135,6 +135,7 @@ pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) ->
 				fallback_max_weight: None,
 				call: DoubleEncoded { encoded: whitelist_info.encoded },
 			},
+			Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
 		]))),
 	});
 
@@ -150,6 +151,7 @@ pub(crate) fn build_polkadot_register_calls(params: RegisterSystemParaParams) ->
 				fallback_max_weight: None,
 				call: DoubleEncoded { encoded: dispatch_info.encoded },
 			},
+			Instruction::ExpectTransactStatus(MaybeErrorCode::Success),
 		]))),
 	});
 

--- a/src/register_system_para.rs
+++ b/src/register_system_para.rs
@@ -227,21 +227,47 @@ async fn register_polkadot_system_para(args: RegisterSystemParaArgs) {
 	proposal_hex.push_str(&hex::encode(&output.proposal.encoded));
 	fs::write(&fname, &proposal_hex).expect("write proposal file");
 
-	// Output summary
+	// Output summary — ordering depends on whether the delay/free-preimage path is used
 	println!("\n{}", "=".repeat(60));
 	println!("  REGISTER SYSTEM PARACHAIN {}", args.para_id);
 	println!("{}", "=".repeat(60));
 	println!();
-	println!("  STEP 1 — Submit on Relay Chain (permissionless):");
-	println!(
-		"    Use force_register_call.hex ({} bytes) as the bytes for",
-		output.force_register_info.length
-	);
-	println!("    Preimage.note_preimage in any wallet (e.g. Polkadot JS Apps).");
-	println!();
-	println!("  STEP 2 — Submit as referendum:");
-	println!("    opengov-cli submit-referendum \\");
-	println!("      --proposal \"{}\" \\", fname);
-	println!("      --network \"polkadot\" --track whitelistedcaller");
+
+	if args.delay_whitelist_dispatch_relay.is_some() {
+		// Delay path: whitelist_call marks the hash as requested during the delay window,
+		// so note_preimage becomes permissionless and free. Submit referendum FIRST.
+		println!("  STEP 1 — Submit as referendum:");
+		println!("    opengov-cli submit-referendum \\");
+		println!("      --proposal \"{}\" \\", fname);
+		println!("      --network \"polkadot\" --track whitelistedcaller");
+		println!();
+		println!("  STEP 2 — After enactment, submit on the relay chain (free):");
+		println!(
+			"    Use force_register_call.hex ({} bytes) as the bytes for",
+			output.force_register_info.length
+		);
+		println!("    Preimage.note_preimage. The hash was marked as requested by");
+		println!("    whitelist_call at enactment, so no deposit is taken. Must be");
+		println!(
+			"    submitted before the scheduled dispatch fires (+{} blocks).",
+			args.delay_whitelist_dispatch_relay.unwrap()
+		);
+	} else {
+		// No-delay path: dispatch fires in the same block as whitelist_call, so the
+		// preimage must exist beforehand. Submitter pays full deposit + fee.
+		println!("  STEP 1 — Submit on Relay Chain (permissioned — pays ~1000 DOT deposit):");
+		println!(
+			"    Use force_register_call.hex ({} bytes) as the bytes for",
+			output.force_register_info.length
+		);
+		println!("    Preimage.note_preimage. Must be stored before the referendum enacts;");
+		println!("    without --delay-whitelist-dispatch-relay, whitelist_call and dispatch");
+		println!("    fire in the same block. Deposit is refunded once governance consumes it.");
+		println!();
+		println!("  STEP 2 — Submit as referendum:");
+		println!("    opengov-cli submit-referendum \\");
+		println!("      --proposal \"{}\" \\", fname);
+		println!("      --network \"polkadot\" --track whitelistedcaller");
+	}
 	println!("{}", "=".repeat(60));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,9 @@
 use crate::get_proposal_bytes;
 use crate::polkadot_asset_hub::runtime_types::frame_system::pallet::Call as PolkadotAssetHubSystemCall;
 use crate::polkadot_relay::runtime_types::frame_system::pallet::Call as PolkadotRelaySystemCall;
+use crate::register_system_para::{
+	build_polkadot_register_calls, RegisterSystemParaParams,
+};
 use crate::{
 	build_upgrade, submit_referendum::generate_calls, CallInfo, CallOrHash,
 	KusamaAssetHubOpenGovOrigin, Network, NetworkRuntimeCall, PolkadotAssetHubOpenGovOrigin,
@@ -599,4 +602,180 @@ fn it_creates_constrained_print_output() {
 		},
 	}
 	assert_eq!(length, proposal_call_info.length);
+}
+
+// ---------------------------------------------------------------------------
+// Register System Para tests
+// ---------------------------------------------------------------------------
+
+/// Small synthetic test params (avoids needing real WASM files).
+fn small_register_params() -> RegisterSystemParaParams {
+	RegisterSystemParaParams {
+		wasm_bytes: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x00], // minimal wasm-like
+		genesis_head_bytes: vec![0x01, 0x02, 0x03, 0x04],
+		para_id: 1234,
+		manager_bytes: [0u8; 32], // zero account
+		deposit: 0,
+		ref_time: 60_000_000_000,
+		proof_size: 10_000,
+	}
+}
+
+#[test]
+fn register_force_register_call_encodes_correctly() {
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// force_register is a relay chain call
+	assert_eq!(output.force_register_info.network, Network::Polkadot);
+	// Encoded bytes should start with Registrar pallet + force_register call index
+	assert!(output.force_register_info.length > 0);
+	// Hash should be 32 bytes
+	assert_eq!(output.force_register_info.hash.len(), 32);
+	// Should be decodable back to a Polkadot call
+	assert!(output.force_register_info.get_polkadot_call().is_ok());
+}
+
+#[test]
+fn register_proposal_is_asset_hub_call() {
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// Proposal is an Asset Hub call (batch_all)
+	assert_eq!(output.proposal.network, Network::PolkadotAssetHub);
+	// Should be decodable as a Polkadot Asset Hub call
+	assert!(output.proposal.get_polkadot_asset_hub_call().is_ok());
+}
+
+#[test]
+fn register_proposal_is_within_ump_limit() {
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// The proposal must be small enough to eventually travel as an XCM UMP message.
+	// The proposal itself is a batch_all of two polkadotXcm.send calls.
+	// It should be well under 128 KB (the UMP limit).
+	assert!(
+		output.proposal.length < 1024,
+		"Proposal is {} bytes, expected < 1024 for small inputs",
+		output.proposal.length
+	);
+}
+
+#[test]
+fn register_whitelist_hash_matches_force_register_hash() {
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// Verify the proposal is decodable and contains the force_register hash.
+	let _proposal_call = output.proposal.get_polkadot_asset_hub_call().expect("valid AH call");
+
+	// The proposal is batch_all([xcm_send_whitelist, xcm_send_dispatch]).
+	// We verify the force_register hash is embedded in the proposal by checking
+	// that the proposal bytes contain the force_register hash.
+	let hash_bytes = output.force_register_info.hash;
+	let proposal_bytes = &output.proposal.encoded;
+
+	// The hash should appear twice in the proposal (once in whitelist_call, once in dispatch)
+	let hash_occurrences = proposal_bytes
+		.windows(32)
+		.filter(|w| *w == hash_bytes)
+		.count();
+	assert_eq!(
+		hash_occurrences, 2,
+		"force_register hash should appear exactly twice in proposal (whitelist + dispatch)"
+	);
+}
+
+#[test]
+fn register_deterministic_output() {
+	// Same inputs should produce identical output.
+	let output1 = build_polkadot_register_calls(small_register_params());
+	let output2 = build_polkadot_register_calls(small_register_params());
+
+	assert_eq!(output1.force_register_info.encoded, output2.force_register_info.encoded);
+	assert_eq!(output1.force_register_info.hash, output2.force_register_info.hash);
+	assert_eq!(output1.proposal.encoded, output2.proposal.encoded);
+}
+
+#[tokio::test]
+async fn register_proposal_works_with_submit_referendum() {
+	// Build the registration proposal, then feed it into submit-referendum
+	// to verify the full pipeline works.
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// Create a ProposalDetails as if the user piped the proposal into submit-referendum
+	use crate::DispatchTimeWrapper::*;
+	use crate::NetworkTrack::*;
+	use crate::Output::*;
+
+	let proposal_hex = format!("0x{}", hex::encode(&output.proposal.encoded));
+
+	let proposal_details = ProposalDetails {
+		proposal: proposal_hex,
+		track: Polkadot(PolkadotAssetHubOpenGovOrigin::WhitelistedCaller),
+		dispatch: After(10),
+		output: CallData,
+		output_len_limit: 1_000,
+		print_batch: false,
+		use_light_client: false,
+		fellowship_on_polkadot: false,
+	};
+
+	let calls = generate_calls(&proposal_details).await;
+
+	// Should generate fellowship referendum (on Collectives)
+	assert!(
+		calls.fellowship_referendum_submission.is_some(),
+		"must generate fellowship referendum"
+	);
+	if let Some(ref fellowship_ref) = calls.fellowship_referendum_submission {
+		match fellowship_ref {
+			NetworkRuntimeCall::PolkadotCollectives(_) => (),
+			other => panic!(
+				"Fellowship referendum should be on PolkadotCollectives, got {:?}",
+				std::mem::discriminant(other)
+			),
+		}
+	}
+
+	// Should generate public referendum preimage (on Asset Hub)
+	assert!(
+		calls.preimage_for_public_referendum.is_some(),
+		"must generate public referendum preimage"
+	);
+
+	// Should generate public referendum (on Asset Hub)
+	assert!(
+		calls.public_referendum_submission.is_some(),
+		"must generate public referendum"
+	);
+	if let Some(ref public_ref) = calls.public_referendum_submission {
+		match public_ref {
+			NetworkRuntimeCall::PolkadotAssetHub(_) => (),
+			other => panic!(
+				"Public referendum should be on PolkadotAssetHub, got {:?}",
+				std::mem::discriminant(other)
+			),
+		}
+	}
+}
+
+#[test]
+fn register_dispatch_whitelisted_has_correct_length() {
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// The dispatch_whitelisted_call inside the XCM should reference the correct
+	// call_encoded_len matching the force_register call length.
+	let force_register_len = output.force_register_info.length;
+
+	// call_encoded_len is a u32, SCALE-encoded as 4 bytes little-endian
+	let len_le = force_register_len.to_le_bytes();
+	assert!(
+		output.proposal.encoded.windows(4).any(|w| w == len_le),
+		"force_register length ({}, le bytes {:?}) should appear in the proposal",
+		force_register_len, len_le,
+	);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -618,6 +618,7 @@ fn small_register_params() -> RegisterSystemParaParams {
 		deposit: 0,
 		ref_time: 60_000_000_000,
 		proof_size: 10_000,
+		assign_core: None,
 	}
 }
 
@@ -685,6 +686,56 @@ fn register_whitelist_hash_matches_force_register_hash() {
 		hash_occurrences, 2,
 		"force_register hash should appear exactly twice in proposal (whitelist + dispatch)"
 	);
+}
+
+#[test]
+fn register_with_assign_core_has_three_expect_transact_status() {
+	let mut params = small_register_params();
+	params.assign_core = Some(67);
+	let output = build_polkadot_register_calls(params);
+
+	// With assign_core, there are 3 XCM messages: whitelist, dispatch, force_reserve.
+	// Each should have ExpectTransactStatus(Success).
+	// V5 enum variant (0x05) followed by compact(3) = 0x0c means 3 instructions per XCM.
+	let v5_three_instructions: [u8; 2] = [0x05, 0x0c];
+	let occurrences = output
+		.proposal
+		.encoded
+		.windows(2)
+		.filter(|w| *w == v5_three_instructions)
+		.count();
+	assert_eq!(
+		occurrences, 3,
+		"Each of the 3 XCM messages should have 3 instructions (UnpaidExecution + Transact + ExpectTransactStatus)"
+	);
+}
+
+#[test]
+fn register_with_assign_core_adds_xcm_to_coretime() {
+	let params = small_register_params();
+	let output_without = build_polkadot_register_calls(params);
+
+	let mut params_with_core = small_register_params();
+	params_with_core.assign_core = Some(67);
+	let output_with = build_polkadot_register_calls(params_with_core);
+
+	// The relay preimage (force_register) should be identical — assign_core goes via
+	// separate XCM to Coretime chain, not in the relay batch.
+	assert_eq!(
+		output_with.force_register_info.encoded, output_without.force_register_info.encoded,
+		"Relay preimage should be the same with or without assign_core"
+	);
+
+	// The AH proposal should be larger (extra XCM send to Coretime chain)
+	assert!(
+		output_with.proposal.length > output_without.proposal.length,
+		"AH proposal with assign_core ({}) should be larger than without ({})",
+		output_with.proposal.length,
+		output_without.proposal.length,
+	);
+
+	// Both proposals should still be valid AH calls
+	assert!(output_with.proposal.get_polkadot_asset_hub_call().is_ok());
 }
 
 #[test]
@@ -760,6 +811,44 @@ async fn register_proposal_works_with_submit_referendum() {
 			),
 		}
 	}
+}
+
+#[test]
+fn register_xcm_includes_expect_transact_status() {
+	let params = small_register_params();
+	let output = build_polkadot_register_calls(params);
+
+	// Build a proposal WITHOUT ExpectTransactStatus to compare.
+	// We verify by checking that each XCM has 3 instructions (not 2):
+	// [UnpaidExecution, Transact, ExpectTransactStatus].
+	//
+	// XCM Vec<Instruction> is SCALE-encoded with a compact length prefix.
+	// 3 instructions = compact(3) = 0x0c as the first byte of the XCM body.
+	// If ExpectTransactStatus were missing, it would be compact(2) = 0x08.
+	//
+	// The proposal is batch_all([send(xcm1), send(xcm2)]).
+	// Each send's message contains V5(Xcm(vec![...3 instructions...])).
+	// The compact(3) = 0x0c prefix should appear exactly twice.
+
+	// Count how many XCM instruction vectors have length 3 (0x0c prefix).
+	// We look for the byte pattern that represents "3 instructions in a Vec".
+	// In the SCALE encoding of Xcm(Vec<Instruction>), the vec length comes right
+	// after the V5 enum variant tag.
+	//
+	// V5 variant index in VersionedXcm is 5 (V2=0, V3=1, V4=2... but encoded as
+	// actual enum index which is 05 for V5). The pattern is:
+	// 0x05 (V5) followed by 0x0c (compact 3 = three instructions)
+	let v5_three_instructions: [u8; 2] = [0x05, 0x0c];
+	let occurrences = output
+		.proposal
+		.encoded
+		.windows(2)
+		.filter(|w| *w == v5_three_instructions)
+		.count();
+	assert_eq!(
+		occurrences, 2,
+		"Each XCM message should have 3 instructions (UnpaidExecution + Transact + ExpectTransactStatus)"
+	);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -895,3 +895,71 @@ fn register_dispatch_whitelisted_has_correct_length() {
 		force_register_len, len_le,
 	);
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests: register-system-para vs composed primitives
+// ---------------------------------------------------------------------------
+
+/// Verify that composing primitives (xcm-force-register + xcm-force-reserve + batch-ah)
+/// produces byte-identical output to `build_polkadot_register_calls`.
+#[test]
+fn composed_primitives_match_register_system_para() {
+	use crate::primitives::{
+		batch_all_on_ah, build_dispatch_whitelisted_call, build_force_register_call,
+		build_force_reserve_call, build_whitelist_call, wrap_in_xcm_send_from_ah,
+		ForceRegisterParams, XcmDest,
+	};
+
+	let mut params = small_register_params();
+	params.assign_core = Some(77);
+	let monolithic = build_polkadot_register_calls(RegisterSystemParaParams {
+		wasm_bytes: params.wasm_bytes.clone(),
+		genesis_head_bytes: params.genesis_head_bytes.clone(),
+		para_id: params.para_id,
+		manager_bytes: params.manager_bytes,
+		deposit: params.deposit,
+		ref_time: params.ref_time,
+		proof_size: params.proof_size,
+		assign_core: params.assign_core,
+		delay_whitelist_dispatch_relay: None,
+	});
+
+	// Compose the same proposal manually using the primitives.
+	let force_register_info = build_force_register_call(ForceRegisterParams {
+		wasm_bytes: params.wasm_bytes.clone(),
+		genesis_head_bytes: params.genesis_head_bytes.clone(),
+		para_id: params.para_id,
+		manager_bytes: params.manager_bytes,
+		deposit: params.deposit,
+	});
+	let whitelist_info = build_whitelist_call(force_register_info.hash);
+	let xcm_whitelist = wrap_in_xcm_send_from_ah(XcmDest::Relay, whitelist_info.encoded);
+
+	let dispatch_call = build_dispatch_whitelisted_call(
+		force_register_info.hash,
+		force_register_info.length,
+		params.ref_time,
+		params.proof_size,
+	);
+	let dispatch_info = CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_call));
+	let xcm_dispatch = wrap_in_xcm_send_from_ah(XcmDest::Relay, dispatch_info.encoded);
+
+	let fr_info = build_force_reserve_call(params.para_id, 77);
+	let xcm_reserve = wrap_in_xcm_send_from_ah(XcmDest::Sibling(1005), fr_info.encoded.clone());
+
+	let composed = batch_all_on_ah(vec![xcm_whitelist, xcm_dispatch, xcm_reserve]);
+
+	// The composed proposal must be byte-identical to the monolithic build.
+	assert_eq!(
+		composed.encoded, monolithic.proposal.encoded,
+		"composed proposal bytes must match register-system-para output"
+	);
+	assert_eq!(composed.hash, monolithic.proposal.hash);
+
+	// And the force_register preimage / force_reserve call must match too.
+	assert_eq!(force_register_info.encoded, monolithic.force_register_info.encoded);
+	assert_eq!(
+		fr_info.encoded,
+		monolithic.force_reserve_info.as_ref().expect("force_reserve_info set").encoded
+	);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -619,6 +619,7 @@ fn small_register_params() -> RegisterSystemParaParams {
 		ref_time: 60_000_000_000,
 		proof_size: 10_000,
 		assign_core: None,
+		delay_whitelist_dispatch_relay: None,
 	}
 }
 
@@ -686,6 +687,32 @@ fn register_whitelist_hash_matches_force_register_hash() {
 		hash_occurrences, 2,
 		"force_register hash should appear exactly twice in proposal (whitelist + dispatch)"
 	);
+}
+
+#[test]
+fn register_delay_whitelist_dispatch_relay_wraps_dispatch_in_scheduler() {
+	let mut params = small_register_params();
+	params.delay_whitelist_dispatch_relay = Some(100);
+	let output_delayed = build_polkadot_register_calls(params);
+
+	let output_normal = build_polkadot_register_calls(small_register_params());
+
+	// The relay preimage should be the same (force_register is unchanged)
+	assert_eq!(
+		output_delayed.force_register_info.encoded, output_normal.force_register_info.encoded,
+		"Relay preimage should be identical regardless of --free-preimage-delay"
+	);
+
+	// The AH proposal should be larger (dispatch wrapped in Scheduler.schedule_after)
+	assert!(
+		output_delayed.proposal.length > output_normal.proposal.length,
+		"Proposal with delay ({}) should be larger than without ({})",
+		output_delayed.proposal.length,
+		output_normal.proposal.length,
+	);
+
+	// Both should still be valid AH calls
+	assert!(output_delayed.proposal.get_polkadot_asset_hub_call().is_ok());
 }
 
 #[test]

--- a/src/xcm_force_register.rs
+++ b/src/xcm_force_register.rs
@@ -1,0 +1,164 @@
+//! `xcm-force-register` subcommand.
+//!
+//! Builds the whitelist + preimage pattern for a relay chain `Registrar.force_register`
+//! call. The ~1 MB WASM payload exceeds the 128 KB UMP limit, so the call is stored as
+//! a preimage on the relay while AH governance whitelists + dispatches it via XCM.
+//!
+//! Outputs (in `--output` directory):
+//! - `preimage.hex`        — raw relay `force_register` bytes (submit via `Preimage.note_preimage`)
+//! - `xcm_whitelist.hex`   — AH XCM: `whitelist.whitelist_call(hash)`
+//! - `xcm_dispatch.hex`    — AH XCM: `whitelist.dispatch_whitelisted_call(hash, len, weight)`,
+//!                           optionally wrapped in `Scheduler.schedule_after(delay, ...)`
+
+use crate::primitives::{
+	build_dispatch_whitelisted_call, build_force_register_call, build_whitelist_call,
+	wrap_in_relay_scheduler, wrap_in_xcm_send_from_ah, ForceRegisterParams, XcmDest,
+};
+use crate::*;
+use clap::Parser as ClapParser;
+use std::fs;
+use std::path::PathBuf;
+
+/// Generate the whitelist+preimage pattern for a relay-chain `force_register` call.
+#[derive(Debug, ClapParser)]
+pub(crate) struct XcmForceRegisterArgs {
+	/// Path to the WASM validation code file.
+	#[clap(long = "wasm")]
+	wasm: String,
+
+	/// Path to the genesis head hex file (from: polkadot-omni-node export-genesis-head).
+	#[clap(long = "genesis-head")]
+	genesis_head: String,
+
+	/// Parachain ID to register.
+	#[clap(long = "para-id")]
+	para_id: u32,
+
+	/// Manager account SS58 address.
+	#[clap(long = "manager")]
+	manager: String,
+
+	/// Network. Currently only `polkadot` is supported.
+	#[clap(long = "network", short, default_value = "polkadot")]
+	network: String,
+
+	/// Deposit in plancks.
+	#[clap(long = "deposit", default_value = "0")]
+	deposit: u128,
+
+	/// Weight ref_time witness for dispatch_whitelisted_call.
+	#[clap(long = "ref-time", default_value = "10000000000")]
+	ref_time: u64,
+
+	/// Weight proof_size witness for dispatch_whitelisted_call.
+	#[clap(long = "proof-size", default_value = "5000")]
+	proof_size: u64,
+
+	/// Delay dispatch_whitelisted_call via `Scheduler.schedule_after(delay)`.
+	/// Enables the free-preimage path: whitelist_call requests the hash, then after `delay`
+	/// relay blocks the dispatch fires. During the window anyone can note_preimage for free.
+	#[clap(long = "delay-whitelist-dispatch-relay")]
+	delay_whitelist_dispatch_relay: Option<u32>,
+
+	/// Output directory for the three hex files.
+	#[clap(long = "output", short, default_value = ".")]
+	output: String,
+}
+
+pub(crate) async fn xcm_force_register(args: XcmForceRegisterArgs) {
+	if args.network.to_ascii_lowercase() != "polkadot" {
+		panic!("Only `--network polkadot` is supported for now.");
+	}
+
+	// Read inputs
+	let wasm_bytes = fs::read(&args.wasm).expect("Should read WASM file");
+	let genesis_head_hex = fs::read_to_string(&args.genesis_head)
+		.expect("Should read genesis head file")
+		.trim()
+		.to_string();
+	let genesis_head_bytes =
+		hex::decode(genesis_head_hex.trim_start_matches("0x")).expect("Valid hex for genesis head");
+
+	use sp_core::crypto::Ss58Codec;
+	let manager_account =
+		sp_core::crypto::AccountId32::from_ss58check(&args.manager).expect("Valid SS58 address");
+	let manager_bytes: [u8; 32] = manager_account.into();
+
+	// Build force_register (the preimage)
+	let force_register_info = build_force_register_call(ForceRegisterParams {
+		wasm_bytes,
+		genesis_head_bytes,
+		para_id: args.para_id,
+		manager_bytes,
+		deposit: args.deposit,
+	});
+
+	// Build whitelist_call(hash) + XCM wrap
+	let whitelist_info = build_whitelist_call(force_register_info.hash);
+	let xcm_whitelist = wrap_in_xcm_send_from_ah(XcmDest::Relay, whitelist_info.encoded);
+	let xcm_whitelist_info =
+		CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(xcm_whitelist));
+
+	// Build dispatch_whitelisted_call, optionally wrap in Scheduler, then XCM wrap
+	let dispatch_call = build_dispatch_whitelisted_call(
+		force_register_info.hash,
+		force_register_info.length,
+		args.ref_time,
+		args.proof_size,
+	);
+	let dispatch_call = match args.delay_whitelist_dispatch_relay {
+		Some(delay) => wrap_in_relay_scheduler(dispatch_call, delay),
+		None => dispatch_call,
+	};
+	let dispatch_info = CallInfo::from_runtime_call(NetworkRuntimeCall::Polkadot(dispatch_call));
+	let xcm_dispatch = wrap_in_xcm_send_from_ah(XcmDest::Relay, dispatch_info.encoded);
+	let xcm_dispatch_info =
+		CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(xcm_dispatch));
+
+	// Ensure output directory exists
+	let out_dir = PathBuf::from(&args.output);
+	fs::create_dir_all(&out_dir).expect("create output directory");
+
+	let preimage_path = out_dir.join("preimage.hex");
+	let whitelist_path = out_dir.join("xcm_whitelist.hex");
+	let dispatch_path = out_dir.join("xcm_dispatch.hex");
+
+	write_hex(&preimage_path, &force_register_info.encoded);
+	write_hex(&whitelist_path, &xcm_whitelist_info.encoded);
+	write_hex(&dispatch_path, &xcm_dispatch_info.encoded);
+
+	println!("XCM force_register (whitelist+preimage):");
+	println!("  Para ID: {}", args.para_id);
+	println!("  Manager: {}", args.manager);
+	println!(
+		"  Preimage (relay force_register): {} bytes, hash 0x{}",
+		force_register_info.length,
+		hex::encode(force_register_info.hash)
+	);
+	println!("    → {}", preimage_path.display());
+	println!(
+		"  XCM whitelist_call: {} bytes → {}",
+		xcm_whitelist_info.length,
+		whitelist_path.display()
+	);
+	if let Some(delay) = args.delay_whitelist_dispatch_relay {
+		println!(
+			"  XCM dispatch (scheduled +{} blocks): {} bytes → {}",
+			delay,
+			xcm_dispatch_info.length,
+			dispatch_path.display()
+		);
+	} else {
+		println!(
+			"  XCM dispatch_whitelisted_call: {} bytes → {}",
+			xcm_dispatch_info.length,
+			dispatch_path.display()
+		);
+	}
+}
+
+fn write_hex(path: &std::path::Path, bytes: &[u8]) {
+	let mut hex_out = "0x".to_owned();
+	hex_out.push_str(&hex::encode(bytes));
+	fs::write(path, &hex_out).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}

--- a/src/xcm_force_reserve.rs
+++ b/src/xcm_force_reserve.rs
@@ -1,0 +1,52 @@
+//! `xcm-force-reserve` subcommand.
+//!
+//! Builds an Asset Hub `PolkadotXcm.send` call to the Coretime chain carrying
+//! a `Transact(Superuser, Broker.force_reserve(schedule, core))`. The output
+//! is a single hex-encoded AH call that can be batched with other AH calls via
+//! `batch-ah`.
+
+use crate::primitives::{build_force_reserve_call, wrap_in_xcm_send_from_ah, XcmDest};
+use crate::*;
+use clap::Parser as ClapParser;
+use std::fs;
+
+/// Generate an AH XCM send wrapping `Broker.force_reserve` for the Coretime chain.
+#[derive(Debug, ClapParser)]
+pub(crate) struct XcmForceReserveArgs {
+	/// Parachain ID to assign to the reserved core.
+	#[clap(long = "para-id")]
+	para_id: u32,
+
+	/// Core index to reserve.
+	#[clap(long = "core")]
+	core: u16,
+
+	/// Network. Currently only `polkadot` is supported.
+	#[clap(long = "network", short, default_value = "polkadot")]
+	network: String,
+
+	/// Output file for the hex-encoded Asset Hub call.
+	#[clap(long = "output", short, default_value = "xcm_force_reserve.hex")]
+	output: String,
+}
+
+pub(crate) async fn xcm_force_reserve(args: XcmForceReserveArgs) {
+	if args.network.to_ascii_lowercase() != "polkadot" {
+		panic!("Only `--network polkadot` is supported for now.");
+	}
+
+	let fr_info = build_force_reserve_call(args.para_id, args.core);
+	let xcm = wrap_in_xcm_send_from_ah(XcmDest::Sibling(1005), fr_info.encoded.clone());
+	let xcm_info = CallInfo::from_runtime_call(NetworkRuntimeCall::PolkadotAssetHub(xcm));
+
+	let mut hex_out = "0x".to_owned();
+	hex_out.push_str(&hex::encode(&xcm_info.encoded));
+	fs::write(&args.output, &hex_out).expect("write output");
+
+	println!("XCM force_reserve (AH → Coretime):");
+	println!("  Para ID: {}", args.para_id);
+	println!("  Core: {}", args.core);
+	println!("  Inner call (Broker.force_reserve) size: {} bytes", fr_info.length);
+	println!("  XCM send size: {} bytes", xcm_info.length);
+	println!("  Written to: {}", args.output);
+}


### PR DESCRIPTION
 Adds composable primitives for building Asset Hub governance proposals that
  register a system parachain and/or reserve cores on Coretime.

  ### New subcommands

  - **`xcm-force-register`** — relay-chain `Registrar.force_register` wrapped in
    the whitelist + preimage pattern, with optional delayed dispatch for the
    free-preimage path. Outputs `preimage.hex`, `xcm_whitelist.hex`, `xcm_dispatch.hex`.
  - **`xcm-force-reserve`** — AH XCM send carrying `Broker.force_reserve(para, core)`.
  - **`batch-ah`** — combines hex-encoded AH calls into a single `Utility.batch_all` proposal.
  - **`register-system-para`** — convenience wrapper that chains the primitives
    above for the common single-para case.

  ### Docs

  See README for details and a worked multi-parachain example.

  ### Real-world scenario

  Used to prepare the Bulletin (para 1010) registration + extra core reservations
  for Polkadot People (para 1004): <https://hackmd.io/@karolk/S1qWzAs2-x>